### PR TITLE
Cherry-pick: renaming to Stake Maturity

### DIFF
--- a/app/src/parser.c
+++ b/app/src/parser.c
@@ -1014,7 +1014,7 @@ static parser_error_t parser_getItemMergeMaturity(uint8_t displayIdx,
 
     if (displayIdx == 0) {
         snprintf(outKey, outKeyLen, "Transaction type");
-        snprintf(outVal, outValLen, "Merge Maturity");
+        snprintf(outVal, outValLen, "Stake Maturity");
         return parser_ok;
     }
 

--- a/tests/manual.json
+++ b/tests/manual.json
@@ -9086,56 +9086,56 @@
     ]
   },
   {
-    "name": "Merge Maturity",
+    "name": "Stake Maturity",
     "index": 1018,
     "blob": "d9d9f7a167636f6e74656e74a66361726746620210016a006b63616e69737465725f69644a000000000000000101016e696e67726573735f6578706972791b16abbe02709595006b6d6574686f645f6e616d65706d616e6167655f6e6575726f6e5f70626c726571756573745f747970656463616c6c6673656e646572581dd899978f029508f4fa5fce3d2539de5aade6d229efcc458233deee7502",
     "output": [
-      "0 | Transaction type : Merge Maturity",
+      "0 | Transaction type : Stake Maturity",
       "1 | Neuron ID : 1",
       "2 | Percentage : 0"
     ],
     "output_expert": [
-      "0 | Transaction type : Merge Maturity",
+      "0 | Transaction type : Stake Maturity",
       "1 | Neuron ID : 1",
       "2 | Percentage : 0"
     ]
   },
   {
-    "name": "Merge Maturity",
+    "name": "Stake Maturity",
     "index": 1019,
     "blob": "d9d9f7a167636f6e74656e74a66361726748620210016a02080e6b63616e69737465725f69644a000000000000000101016e696e67726573735f6578706972791b16abbdeb03397c406b6d6574686f645f6e616d65706d616e6167655f6e6575726f6e5f70626c726571756573745f747970656463616c6c6673656e646572581dd899978f029508f4fa5fce3d2539de5aade6d229efcc458233deee7502",
     "output": [
-      "0 | Transaction type : Merge Maturity",
+      "0 | Transaction type : Stake Maturity",
       "1 | Neuron ID : 1",
       "2 | Percentage : 14"
     ],
     "output_expert": [
-      "0 | Transaction type : Merge Maturity",
+      "0 | Transaction type : Stake Maturity",
       "1 | Neuron ID : 1",
       "2 | Percentage : 14"
     ]
   },
   {
-    "name": "Merge Maturity",
+    "name": "Stake Maturity",
     "index": 1020,
     "blob": "d9d9f7a167636f6e74656e74a66361726748620210016a0208646b63616e69737465725f69644a000000000000000101016e696e67726573735f6578706972791b16abbdfdfadb7a406b6d6574686f645f6e616d65706d616e6167655f6e6575726f6e5f70626c726571756573745f747970656463616c6c6673656e646572581dd899978f029508f4fa5fce3d2539de5aade6d229efcc458233deee7502",
     "output": [
-      "0 | Transaction type : Merge Maturity",
+      "0 | Transaction type : Stake Maturity",
       "1 | Neuron ID : 1",
       "2 | Percentage : 100"
     ],
     "output_expert": [
-    "0 | Transaction type : Merge Maturity",
+    "0 | Transaction type : Stake Maturity",
     "1 | Neuron ID : 1",
     "2 | Percentage : 100"
   ]
   },
-//  {
-//    "name": "Merge Maturity",
-//    "index" : 1021,
-//    "blob": "d9d9f7a167636f6e74656e74a66361726748620210016a0208656b63616e69737465725f69644a000000000000000101016e696e67726573735f6578706972791b16abc46ecbf1b9c06b6d6574686f645f6e616d65706d616e6167655f6e6575726f6e5f70626c726571756573745f747970656463616c6c6673656e646572581dd899978f029508f4fa5fce3d2539de5aade6d229efcc458233deee7502",
-//    "valid": false
-//  },
+ {
+   "name": "Stake Maturity",
+   "index" : 1021,
+   "blob": "d9d9f7a167636f6e74656e74a66361726748620210016a0208656b63616e69737465725f69644a000000000000000101016e696e67726573735f6578706972791b16abc46ecbf1b9c06b6d6574686f645f6e616d65706d616e6167655f6e6575726f6e5f70626c726571756573745f747970656463616c6c6673656e646572581dd899978f029508f4fa5fce3d2539de5aade6d229efcc458233deee7502",
+   "valid": false
+ },
   {
     "name": "Register Vote",
     "index" : 1022,

--- a/tests_zemu/tests/phase2.test.ts
+++ b/tests_zemu/tests/phase2.test.ts
@@ -313,7 +313,7 @@ describe('Phase2', function () {
     }
   })
 
-  test.each(DEVICE_MODELS)('sign normal -- Merge Mature', async function (m) {
+  test.each(DEVICE_MODELS)('sign normal -- Stake Mature', async function (m) {
     const sim = new Zemu(m.path)
     try {
       await sim.start({ ...DEFAULT_OPTIONS, model: m.name })
@@ -327,8 +327,7 @@ describe('Phase2', function () {
 
       // Wait until we are not in the main menu
       await sim.waitUntilScreenIsNot(sim.getMainMenuSnapshot())
-
-      await sim.compareSnapshotsAndAccept('.', `${m.prefix.toLowerCase()}-sign_MergeMature`, m.name === 'nanos' ? 3 : 4)
+      await sim.compareSnapshotsAndApprove('.', `${m.prefix.toLowerCase()}-sign_StakeMature`)
 
       const signatureResponse = await respRequest
       console.log(signatureResponse)


### PR DESCRIPTION
Cherry-pick from e2ee0fea4550f3281e5a8e7e168df41c689b1540 wich was merged on main on #13.
[ftheirs](https://github.com/ftheirs) can you have a look?
I stumbled on a conflict with previous changes on `app-icp/tests/ui_tests.cpp` not in `main`, but in `develop`: https://github.com/LedgerHQ/app-icp/commit/fd9847c577fea8070a80781cb53e850c2f20d60c#diff-86f721431649b48ffe7c4374a0f90dc098e2a9fafa22b16d1c7582217ac68afd
I choose to keep the version already present in `develop`